### PR TITLE
Update base image to use amazoncorretto:8u232

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8u181-jdk
+FROM amazoncorretto:8u232
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         make \


### PR DESCRIPTION
Update base image to use amazoncorretto:8u232 

Dockerfile for corretto: https://github.com/corretto/corretto-8-docker
Dockerfile for openjdk:https://github.com/docker-library/openjdk/blob/master/8/jdk/Dockerfile

Benefits of Amazon Corretto
- corretto is downstream dist of `openjdk`
- no-cost TLS
- at least quarterly releases
- drop-in replacement